### PR TITLE
fix: implement internal API key authentication for emergency alerts (#4)

### DIFF
--- a/apps/backend/src/main/java/com/aicc/silverlink/domain/emergency/controller/EmergencyAlertInternalController.java
+++ b/apps/backend/src/main/java/com/aicc/silverlink/domain/emergency/controller/EmergencyAlertInternalController.java
@@ -18,9 +18,9 @@ import org.springframework.web.bind.annotation.*;
  * 긴급 알림 내부 API 컨트롤러
  * CallBot 시스템에서 호출하는 내부 전용 API
  *
- * 보안: 이 API는 내부 네트워크에서만 접근 가능해야 함
- * - API Gateway에서 /api/internal/** 경로 차단
- * - 또는 별도의 API Key 인증 적용
+ * 보안: InternalApiKeyAuthFilter에서 X-Internal-Api-Key 헤더 검증
+ * - application.yml의 internal.api.key 값과 비교
+ * - 일치하지 않으면 401 Unauthorized 반환
  */
 @Slf4j
 @RestController
@@ -42,11 +42,7 @@ public class EmergencyAlertInternalController {
         @Operation(summary = "긴급 알림 생성", description = "CallBot에서 위험 감지 시 긴급 알림을 생성합니다. " +
                         "알림 생성 후 자동으로 관리자, 상담사, 보호자에게 웹/SMS 알림이 발송됩니다.")
         public ResponseEntity<?> createAlert(
-                        @Valid @RequestBody CreateRequest request,
-                        @RequestHeader(value = "X-Internal-Api-Key", required = false) String apiKey) {
-
-                // TODO: 내부 API 키 검증 (실제 구현 필요)
-                // validateInternalApiKey(apiKey);
+                        @Valid @RequestBody CreateRequest request) {
 
                 log.info("[Internal API] POST /api/internal/emergency-alerts - 긴급 알림 생성 요청. " +
                                 "elderlyId={}, severity={}, alertType={}",
@@ -83,8 +79,7 @@ public class EmergencyAlertInternalController {
         @PostMapping("/health")
         @Operation(summary = "건강 위험 알림 생성", description = "건강 관련 위험 키워드 감지 시 CRITICAL 수준의 긴급 알림을 생성합니다.")
         public ResponseEntity<ApiResponse<RealtimeResponse>> createHealthAlert(
-                        @RequestBody HealthAlertRequest request,
-                        @RequestHeader(value = "X-Internal-Api-Key", required = false) String apiKey) {
+                        @RequestBody HealthAlertRequest request) {
 
                 log.info("[Internal API] POST /api/internal/emergency-alerts/health - 건강 위험 알림. " +
                                 "elderlyId={}, callId={}",
@@ -116,8 +111,7 @@ public class EmergencyAlertInternalController {
         @Operation(summary = "정서 위험 알림 생성", description = "정서적 위험 표현 감지 시 긴급 알림을 생성합니다. " +
                         "자해/자살 암시는 CRITICAL, 우울감/외로움은 WARNING으로 생성됩니다.")
         public ResponseEntity<ApiResponse<RealtimeResponse>> createMentalAlert(
-                        @RequestBody MentalAlertRequest request,
-                        @RequestHeader(value = "X-Internal-Api-Key", required = false) String apiKey) {
+                        @RequestBody MentalAlertRequest request) {
 
                 log.info("[Internal API] POST /api/internal/emergency-alerts/mental - 정서 위험 알림. " +
                                 "elderlyId={}, callId={}, isCritical={}",
@@ -153,8 +147,7 @@ public class EmergencyAlertInternalController {
         @PostMapping("/no-response")
         @Operation(summary = "연속 미응답 알림 생성", description = "연속 미응답 감지 시 WARNING 수준의 긴급 알림을 생성합니다.")
         public ResponseEntity<ApiResponse<RealtimeResponse>> createNoResponseAlert(
-                        @RequestBody NoResponseAlertRequest request,
-                        @RequestHeader(value = "X-Internal-Api-Key", required = false) String apiKey) {
+                        @RequestBody NoResponseAlertRequest request) {
 
                 log.info("[Internal API] POST /api/internal/emergency-alerts/no-response - 연속 미응답 알림. " +
                                 "elderlyId={}, attemptCount={}",

--- a/apps/backend/src/main/java/com/aicc/silverlink/global/config/internal/InternalApiProperties.java
+++ b/apps/backend/src/main/java/com/aicc/silverlink/global/config/internal/InternalApiProperties.java
@@ -1,0 +1,32 @@
+package com.aicc.silverlink.global.config.internal;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Internal API authentication properties.
+ *
+ * application.yml:
+ * internal:
+ * api:
+ * key: ${INTERNAL_API_KEY:default-dev-key}
+ * enabled: true
+ */
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "internal.api")
+public class InternalApiProperties {
+
+    /**
+     * Secret key for internal API authentication.
+     * Must match the X-Internal-Api-Key header value sent by CallBot.
+     */
+    private String key;
+
+    /**
+     * Enable/disable internal API key validation.
+     * Set to false for local development without CallBot.
+     */
+    private boolean enabled = true;
+}

--- a/apps/backend/src/main/java/com/aicc/silverlink/global/config/security/SecurityConfig.java
+++ b/apps/backend/src/main/java/com/aicc/silverlink/global/config/security/SecurityConfig.java
@@ -1,6 +1,8 @@
 package com.aicc.silverlink.global.config.security;
 
 import com.aicc.silverlink.domain.session.service.SessionService;
+import com.aicc.silverlink.global.config.internal.InternalApiProperties;
+import com.aicc.silverlink.global.security.filter.InternalApiKeyAuthFilter;
 import com.aicc.silverlink.global.security.jwt.JwtAuthenticationFilter;
 import com.aicc.silverlink.global.security.jwt.JwtProperties;
 import com.aicc.silverlink.global.security.jwt.JwtTokenProvider;
@@ -31,12 +33,13 @@ import java.util.List;
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
-@EnableConfigurationProperties(JwtProperties.class)
+@EnableConfigurationProperties({ JwtProperties.class, InternalApiProperties.class })
 @RequiredArgsConstructor
 public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final SessionService sessionService;
+    private final InternalApiProperties internalApiProperties;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -71,6 +74,7 @@ public class SecurityConfig {
                                 "/calls/{callId}/llm/prompt",
                                 "/calls/{callId}/llm/reply",
                                 "/api/internal/callbot/**",
+                                "/api/internal/emergency-alerts/**",
                                 "/api/debug/**")
                         .permitAll()
 
@@ -85,6 +89,11 @@ public class SecurityConfig {
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint(authenticationEntryPoint())
                         .accessDeniedHandler(accessDeniedHandler()))
+
+                // Internal API Key filter (runs before JWT filter)
+                .addFilterBefore(
+                        new InternalApiKeyAuthFilter(internalApiProperties),
+                        UsernamePasswordAuthenticationFilter.class)
 
                 // JWT 필터 추가
                 .addFilterBefore(

--- a/apps/backend/src/main/java/com/aicc/silverlink/global/security/filter/InternalApiKeyAuthFilter.java
+++ b/apps/backend/src/main/java/com/aicc/silverlink/global/security/filter/InternalApiKeyAuthFilter.java
@@ -1,0 +1,111 @@
+package com.aicc.silverlink.global.security.filter;
+
+import com.aicc.silverlink.global.config.internal.InternalApiProperties;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
+/**
+ * Servlet filter that validates the X-Internal-Api-Key header
+ * for all requests to /api/internal/** (excluding /api/internal/callbot/**).
+ *
+ * <p>
+ * This filter runs before the JWT authentication filter and uses
+ * constant-time comparison to prevent timing attacks.
+ * </p>
+ *
+ * <p>
+ * When {@code internal.api.enabled} is {@code false}, the filter
+ * is skipped entirely (useful for local development).
+ * </p>
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class InternalApiKeyAuthFilter extends OncePerRequestFilter {
+
+    private static final String HEADER_NAME = "X-Internal-Api-Key";
+    private static final String INTERNAL_PATH_PREFIX = "/api/internal/";
+    private static final String CALLBOT_PATH_PREFIX = "/api/internal/callbot/";
+
+    private final InternalApiProperties properties;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String path = request.getRequestURI();
+
+        // Only intercept /api/internal/** paths (excluding /api/internal/callbot/**)
+        if (!isInternalApiPath(path)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // Skip validation when disabled (local development)
+        if (!properties.isEnabled()) {
+            log.debug("[InternalApiKeyAuthFilter] API key validation disabled. Allowing request to {}", path);
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String providedKey = request.getHeader(HEADER_NAME);
+
+        if (providedKey == null || providedKey.isBlank()) {
+            log.warn("[InternalApiKeyAuthFilter] Missing {} header for request to {}", HEADER_NAME, path);
+            sendUnauthorized(response, "Missing " + HEADER_NAME + " header");
+            return;
+        }
+
+        if (!isValidApiKey(providedKey)) {
+            log.warn("[InternalApiKeyAuthFilter] Invalid API key for request to {}", path);
+            sendUnauthorized(response, "Invalid API key");
+            return;
+        }
+
+        log.debug("[InternalApiKeyAuthFilter] API key validated for request to {}", path);
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * Check if the request path is an internal API path that requires key
+     * validation.
+     * Excludes /api/internal/callbot/** which has its own authentication mechanism.
+     */
+    private boolean isInternalApiPath(String path) {
+        return path.startsWith(INTERNAL_PATH_PREFIX) && !path.startsWith(CALLBOT_PATH_PREFIX);
+    }
+
+    /**
+     * Validate the provided API key using constant-time comparison
+     * to prevent timing attacks.
+     */
+    private boolean isValidApiKey(String providedKey) {
+        String configuredKey = properties.getKey();
+        if (configuredKey == null || configuredKey.isBlank()) {
+            log.error("[InternalApiKeyAuthFilter] Internal API key is not configured! " +
+                    "Set 'internal.api.key' in application.yml or INTERNAL_API_KEY env variable.");
+            return false;
+        }
+
+        byte[] provided = providedKey.getBytes(StandardCharsets.UTF_8);
+        byte[] configured = configuredKey.getBytes(StandardCharsets.UTF_8);
+        return MessageDigest.isEqual(provided, configured);
+    }
+
+    private void sendUnauthorized(HttpServletResponse response, String message) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(
+                "{\"error\": \"UNAUTHORIZED\", \"message\": \"" + message + "\"}");
+    }
+}

--- a/apps/backend/src/main/resources/application.yml
+++ b/apps/backend/src/main/resources/application.yml
@@ -114,6 +114,12 @@ callbot:
     connect-timeout: 5000
     read-timeout: 10000
 
+# Internal API authentication (CallBot → Backend)
+internal:
+  api:
+    key: ${INTERNAL_API_KEY:default-dev-key}
+    enabled: ${INTERNAL_API_AUTH_ENABLED:true}
+
 
 
 

--- a/apps/backend/src/test/java/com/aicc/silverlink/global/security/filter/InternalApiKeyAuthFilterTest.java
+++ b/apps/backend/src/test/java/com/aicc/silverlink/global/security/filter/InternalApiKeyAuthFilterTest.java
@@ -1,0 +1,182 @@
+package com.aicc.silverlink.global.security.filter;
+
+import com.aicc.silverlink.global.config.internal.InternalApiProperties;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link InternalApiKeyAuthFilter}.
+ */
+class InternalApiKeyAuthFilterTest {
+
+    private static final String VALID_API_KEY = "test-secret-key-12345";
+    private static final String HEADER_NAME = "X-Internal-Api-Key";
+
+    private InternalApiProperties properties;
+    private InternalApiKeyAuthFilter filter;
+    private FilterChain filterChain;
+
+    @BeforeEach
+    void setUp() {
+        properties = new InternalApiProperties();
+        properties.setKey(VALID_API_KEY);
+        properties.setEnabled(true);
+        filter = new InternalApiKeyAuthFilter(properties);
+        filterChain = mock(FilterChain.class);
+    }
+
+    @Nested
+    @DisplayName("When request targets /api/internal/emergency-alerts/**")
+    class InternalEmergencyAlertPaths {
+
+        @Test
+        @DisplayName("Should pass through with valid API key")
+        void validApiKey_ShouldPassThrough() throws ServletException, IOException {
+            MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/internal/emergency-alerts");
+            request.addHeader(HEADER_NAME, VALID_API_KEY);
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            filter.doFilterInternal(request, response, filterChain);
+
+            verify(filterChain).doFilter(request, response);
+            assertThat(response.getStatus()).isEqualTo(200);
+        }
+
+        @Test
+        @DisplayName("Should return 401 with invalid API key")
+        void invalidApiKey_ShouldReturn401() throws ServletException, IOException {
+            MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/internal/emergency-alerts");
+            request.addHeader(HEADER_NAME, "wrong-key");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            filter.doFilterInternal(request, response, filterChain);
+
+            verify(filterChain, never()).doFilter(request, response);
+            assertThat(response.getStatus()).isEqualTo(401);
+            assertThat(response.getContentAsString()).contains("Invalid API key");
+        }
+
+        @Test
+        @DisplayName("Should return 401 when API key header is missing")
+        void missingApiKey_ShouldReturn401() throws ServletException, IOException {
+            MockHttpServletRequest request = new MockHttpServletRequest("POST",
+                    "/api/internal/emergency-alerts/health");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            filter.doFilterInternal(request, response, filterChain);
+
+            verify(filterChain, never()).doFilter(request, response);
+            assertThat(response.getStatus()).isEqualTo(401);
+            assertThat(response.getContentAsString()).contains("Missing");
+        }
+
+        @Test
+        @DisplayName("Should return 401 when API key header is blank")
+        void blankApiKey_ShouldReturn401() throws ServletException, IOException {
+            MockHttpServletRequest request = new MockHttpServletRequest("POST",
+                    "/api/internal/emergency-alerts/mental");
+            request.addHeader(HEADER_NAME, "   ");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            filter.doFilterInternal(request, response, filterChain);
+
+            verify(filterChain, never()).doFilter(request, response);
+            assertThat(response.getStatus()).isEqualTo(401);
+        }
+    }
+
+    @Nested
+    @DisplayName("When request targets non-internal paths")
+    class NonInternalPaths {
+
+        @Test
+        @DisplayName("Should pass through without checking API key")
+        void nonInternalPath_ShouldPassThrough() throws ServletException, IOException {
+            MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/auth/login");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            filter.doFilterInternal(request, response, filterChain);
+
+            verify(filterChain).doFilter(request, response);
+            assertThat(response.getStatus()).isEqualTo(200);
+        }
+
+        @Test
+        @DisplayName("Should pass through for /api/internal/callbot/** paths")
+        void callbotPath_ShouldPassThrough() throws ServletException, IOException {
+            MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/internal/callbot/some-endpoint");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            filter.doFilterInternal(request, response, filterChain);
+
+            verify(filterChain).doFilter(request, response);
+            assertThat(response.getStatus()).isEqualTo(200);
+        }
+    }
+
+    @Nested
+    @DisplayName("When filter is disabled")
+    class FilterDisabled {
+
+        @Test
+        @DisplayName("Should pass through all internal requests without validation")
+        void disabledFilter_ShouldPassThrough() throws ServletException, IOException {
+            properties.setEnabled(false);
+
+            MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/internal/emergency-alerts");
+            // No API key header set
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            filter.doFilterInternal(request, response, filterChain);
+
+            verify(filterChain).doFilter(request, response);
+            assertThat(response.getStatus()).isEqualTo(200);
+        }
+    }
+
+    @Nested
+    @DisplayName("When API key is not configured")
+    class ApiKeyNotConfigured {
+
+        @Test
+        @DisplayName("Should return 401 when server key is null")
+        void nullServerKey_ShouldReturn401() throws ServletException, IOException {
+            properties.setKey(null);
+
+            MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/internal/emergency-alerts");
+            request.addHeader(HEADER_NAME, "some-key");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            filter.doFilterInternal(request, response, filterChain);
+
+            verify(filterChain, never()).doFilter(request, response);
+            assertThat(response.getStatus()).isEqualTo(401);
+        }
+
+        @Test
+        @DisplayName("Should return 401 when server key is blank")
+        void blankServerKey_ShouldReturn401() throws ServletException, IOException {
+            properties.setKey("   ");
+
+            MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/internal/emergency-alerts");
+            request.addHeader(HEADER_NAME, "some-key");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            filter.doFilterInternal(request, response, filterChain);
+
+            verify(filterChain, never()).doFilter(request, response);
+            assertThat(response.getStatus()).isEqualTo(401);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

누락된 서버간 API 인증 추가 및 기존 JWT 기반 인증을 Internal API Key 인증으로 통합

## Related Issue

https://github.com/ChanJu789/SilverLink/issues/4

Closes #4 

## Type of Change

<!-- Check all that apply. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ♻️ Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] 📝 Documentation (updates to docs, README, or comments)
- [ ] 🧪 Test (adding or updating tests)
- [ ] 🔧 Chore (build process, CI/CD, dependency updates)

## Changes Made

- 기존에는 JWT 토큰을 가진 인증된 사용자(보호자, 상담사 등)들 모두가 API 호출로 긴급 알림 기능을 호출할 수 있었던 보안 문제 존재
- 또한 Chatbot의 JWT 기반 인증 프로세스를 internal API auth로 변경(로그인 딜레이 제거 등 개선)