### PR TITLE
fix: correct totalCount and todayCount in notification stats API (#6)

### DIFF
--- a/apps/backend/src/main/java/com/aicc/silverlink/domain/notification/repository/NotificationRepository.java
+++ b/apps/backend/src/main/java/com/aicc/silverlink/domain/notification/repository/NotificationRepository.java
@@ -45,6 +45,23 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
         long countUnreadByReceiverId(@Param("userId") Long userId);
 
         /**
+         * 사용자별 전체 알림 수
+         */
+        @Query("SELECT COUNT(n) FROM Notification n " +
+                        "WHERE n.receiver.id = :userId")
+        long countByReceiverId(@Param("userId") Long userId);
+
+        /**
+         * 사용자별 기간별 알림 수
+         */
+        @Query("SELECT COUNT(n) FROM Notification n " +
+                        "WHERE n.receiver.id = :userId AND n.createdAt BETWEEN :start AND :end")
+        long countByReceiverIdAndDateRange(
+                        @Param("userId") Long userId,
+                        @Param("start") LocalDateTime start,
+                        @Param("end") LocalDateTime end);
+
+        /**
          * 사용자별 알림 유형별 조회
          */
         @Query("SELECT n FROM Notification n " +

--- a/apps/backend/src/main/java/com/aicc/silverlink/domain/notification/service/NotificationService.java
+++ b/apps/backend/src/main/java/com/aicc/silverlink/domain/notification/service/NotificationService.java
@@ -418,12 +418,12 @@ public class NotificationService {
      * 사용자별 알림 통계
      */
     public StatsResponse getStats(Long userId) {
-        long totalCount = notificationRepository.countUnreadByReceiverId(userId);
+        long totalCount = notificationRepository.countByReceiverId(userId);
         long unreadCount = notificationRepository.countUnreadByReceiverId(userId);
 
         LocalDateTime todayStart = LocalDateTime.now().with(LocalTime.MIN);
         LocalDateTime todayEnd = LocalDateTime.now().with(LocalTime.MAX);
-        long todayCount = notificationRepository.countByDateRange(todayStart, todayEnd);
+        long todayCount = notificationRepository.countByReceiverIdAndDateRange(userId, todayStart, todayEnd);
 
         List<Object[]> typeCounts = notificationRepository.countByTypeForUser(userId);
         List<StatsResponse.TypeCount> countByType = typeCounts.stream()

--- a/apps/backend/src/test/java/com/aicc/silverlink/domain/notification/service/NotificationServiceTest.java
+++ b/apps/backend/src/test/java/com/aicc/silverlink/domain/notification/service/NotificationServiceTest.java
@@ -302,15 +302,19 @@ class NotificationServiceTest {
         @DisplayName("성공 - 사용자별 알림 통계 조회")
         void getStats_Success() {
             // given
-            given(notificationRepository.count()).willReturn(10L);
+            given(notificationRepository.countByReceiverId(1L)).willReturn(10L);
             given(notificationRepository.countUnreadByReceiverId(1L)).willReturn(3L);
+            given(notificationRepository.countByReceiverIdAndDateRange(eq(1L), any(), any())).willReturn(2L);
             given(notificationRepository.countByTypeForUser(1L)).willReturn(List.of());
 
             // when
             StatsResponse stats = notificationService.getStats(1L);
 
             // then
+            assertThat(stats.getTotalCount()).isEqualTo(10);
             assertThat(stats.getUnreadCount()).isEqualTo(3);
+            assertThat(stats.getTodayCount()).isEqualTo(2);
+            assertThat(stats.getTotalCount()).isNotEqualTo(stats.getUnreadCount());
         }
     }
 


### PR DESCRIPTION
## Summary

Fix two bugs in `NotificationService.getStats()` where `totalCount` always equaled `unreadCount`, and `todayCount` was not filtered by user.

## Related Issue

Closes #6

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] 📝 Documentation (updates to docs, README, or comments)
- [x] 🧪 Test (adding or updating tests)
- [ ] 🔧 Chore (build process, CI/CD, dependency updates)

## Changes Made

- **[NotificationRepository.java](cci:7://file:///d:/Programming/SilverLink/apps/backend/src/main/java/com/aicc/silverlink/domain/notification/repository/NotificationRepository.java:0:0-0:0)**: Add [countByReceiverId()](cci:1://file:///d:/Programming/SilverLink/apps/backend/src/main/java/com/aicc/silverlink/domain/notification/repository/NotificationRepository.java:46:8-51:61) for total notifications per user and [countByReceiverIdAndDateRange()](cci:1://file:///d:/Programming/SilverLink/apps/backend/src/main/java/com/aicc/silverlink/domain/notification/repository/NotificationRepository.java:53:8-61:57) for user-filtered date range count
- **[NotificationService.java](cci:7://file:///d:/Programming/SilverLink/apps/backend/src/main/java/com/aicc/silverlink/domain/notification/service/NotificationService.java:0:0-0:0)**: Fix [getStats()](cci:1://file:///d:/Programming/SilverLink/apps/backend/src/main/java/com/aicc/silverlink/domain/notification/service/NotificationService.java:416:4-442:5) to use [countByReceiverId()](cci:1://file:///d:/Programming/SilverLink/apps/backend/src/main/java/com/aicc/silverlink/domain/notification/repository/NotificationRepository.java:46:8-51:61) for `totalCount` (was [countUnreadByReceiverId()](cci:1://file:///d:/Programming/SilverLink/apps/backend/src/main/java/com/aicc/silverlink/domain/notification/repository/NotificationRepository.java:39:8-44:67)) and [countByReceiverIdAndDateRange()](cci:1://file:///d:/Programming/SilverLink/apps/backend/src/main/java/com/aicc/silverlink/domain/notification/repository/NotificationRepository.java:53:8-61:57) for `todayCount` (was [countByDateRange()](cci:1://file:///d:/Programming/SilverLink/apps/backend/src/main/java/com/aicc/silverlink/domain/notification/repository/NotificationRepository.java:154:8-159:100) without user filter)
- **[NotificationServiceTest.java](cci:7://file:///d:/Programming/SilverLink/apps/backend/src/test/java/com/aicc/silverlink/domain/notification/service/NotificationServiceTest.java:0:0-0:0)**: Fix incorrect stub ([count()](cci:1://file:///d:/Programming/SilverLink/apps/backend/src/main/java/com/aicc/silverlink/domain/notification/repository/NotificationRepository.java:154:8-159:100) → [countByReceiverId()](cci:1://file:///d:/Programming/SilverLink/apps/backend/src/main/java/com/aicc/silverlink/domain/notification/repository/NotificationRepository.java:46:8-51:61)), add [countByReceiverIdAndDateRange()](cci:1://file:///d:/Programming/SilverLink/apps/backend/src/main/java/com/aicc/silverlink/domain/notification/repository/NotificationRepository.java:53:8-61:57) stub, and add assertions for `totalCount`, `todayCount`, and `totalCount != unreadCount`

## Screenshots / Recordings

<details>
<summary>📸 Visual Changes</summary>

N/A — backend-only logic fix, no visual changes.

</details>

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests needed (explain why)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
- [x] New and existing tests pass locally
- [ ] CI pipeline passes ✅

## Reviewer Notes

- The existing test was also buggy: it stubbed [count()](cci:1://file:///d:/Programming/SilverLink/apps/backend/src/main/java/com/aicc/silverlink/domain/notification/repository/NotificationRepository.java:154:8-159:100) (never called by the service) and didn't assert `totalCount` at all, so the bug was never caught by tests.
- [countByDateRange()](cci:1://file:///d:/Programming/SilverLink/apps/backend/src/main/java/com/aicc/silverlink/domain/notification/repository/NotificationRepository.java:154:8-159:100) in the repository is now unused after this change — consider removing it in a follow-up cleanup if no other code references it.
